### PR TITLE
Upgrade to Elixir 1.4

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Coap.Mixfile do
      elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   def application do

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule Coap.Mixfile do
   defp deps do
     [
       {:gen_coap, git: "https://github.com/gotthardp/gen_coap.git"},
-      {:apex, "~>0.4.0"}
+      {:apex, "~> 1.0.0"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,2 @@
 %{"apex": {:hex, :apex, "1.0.0", "abf230314d35ca4c48a902f693247f190ad42fc14862b9c4f7dbb7077b21c20a", [:mix], []},
-  "gen_coap": {:git, "https://github.com/gotthardp/gen_coap.git", "fcd54846c86b8b8d4d2c2e81f19afd8bafa89686", []}}
+  "gen_coap": {:git, "https://github.com/gotthardp/gen_coap.git", "dcb84f908d2a3a717554d577a60cfdef978e4463", []}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,2 @@
-%{"apex": {:hex, :apex, "0.4.0"},
+%{"apex": {:hex, :apex, "1.0.0", "abf230314d35ca4c48a902f693247f190ad42fc14862b9c4f7dbb7077b21c20a", [:mix], []},
   "gen_coap": {:git, "https://github.com/gotthardp/gen_coap.git", "fcd54846c86b8b8d4d2c2e81f19afd8bafa89686", []}}


### PR DESCRIPTION
Nice project! Here are a few small changes to clear warnings when using Erlang 19.2 and Elixir 1.4.